### PR TITLE
add sensor update to sync_bring

### DIFF
--- a/custom_components/shopping_list/__init__.py
+++ b/custom_components/shopping_list/__init__.py
@@ -415,7 +415,9 @@ class ShoppingData:
             self.map_items[itm.id] = itm
 
         self.items = [itm.to_ha() for k, itm in self.map_items.items()]
-
+        
+        await self.hass.async_add_executor_job(self.save)
+        
     async def async_load(self):
         """Load items."""
 


### PR DESCRIPTION
Problem:
According to your tutorial https://smarthomeyourself.de/wiki/homeassistant/bring-shopping-list-in-homeassistant/ a custom sensor showing the shopping list content can be added. However, this sensor is not updated, if the shopping list is changed via the bring app. 

To following thread describes the problem and a possible solution:
https://forum.heimnetz.de/threads/sensor-attribute-aktuallisieren.1592/

With this PR the proposed solution can be merged to the main project.
